### PR TITLE
Incorrect message when directory is not writable

### DIFF
--- a/php/qqFileUploader.php
+++ b/php/qqFileUploader.php
@@ -64,7 +64,7 @@ class qqFileUploader {
         $folderInaccessible = ($isWin) ? !is_writable($uploadDirectory) : ( !is_writable($uploadDirectory) && !is_executable($uploadDirectory) );
 
         if ($folderInaccessible){
-            return array('error' => "Server error. Uploads directory isn't writable" . (!$isWin) ? " or executable." : ".");
+            return array('error' => "Server error. Uploads directory isn't writable" . ((!$isWin) ? " or executable." : "."));
         }
 
         if(!isset($_SERVER['CONTENT_TYPE'])) {


### PR DESCRIPTION
When directory is not writable and user tries to upload file, the error message returned says " or executable", but it should be "Server error. Uploads directory isn't writable". That's because ternary operator has left associativity and lower precedence than string operator. Adding more brackets is enough to fix this.
