### PR TITLE
Fixed: uploading '.xlsx' or '.docx' gets corrupt

### DIFF
--- a/ASP.Net_VB/UploadController.vb
+++ b/ASP.Net_VB/UploadController.vb
@@ -12,13 +12,13 @@ Namespace Uploader
 
             ' We need to hand IE a little bit differently...
             If Request.Browser.Browser = "IE" And Request.Browser.MajorVersion < 10 Then
-    	    	' We need to hand IE a little bit differently...
-    			Dim myfiles As System.Web.HttpFileCollection = System.Web.HttpContext.Current.Request.Files
-    		    Dim postedFile As System.Web.HttpPostedFile = myfiles(0)
-    	        If Not postedFile.FileName.Equals("") Then
-    	            fStream = postedFile.InputStream
-    	        End If
-    	    End If
+                ' We need to hand IE a little bit differently...
+                Dim myfiles As System.Web.HttpFileCollection = System.Web.HttpContext.Current.Request.Files
+                Dim postedFile As System.Web.HttpPostedFile = myfiles(0)
+                If Not postedFile.FileName.Equals("") Then
+                    fStream = postedFile.InputStream
+                End If
+            End If
 
             Dim fileContents() As Byte = New Byte(fStream.Length - 1) {}
             fStream.Read(fileContents, 0, CType(fStream.Length, Integer))


### PR DESCRIPTION
Uploading a '.xlsx' or '.docx' corrupted the file and made it exactly 1024 KB.
I fixed the problem with the help of the following stackoverflow post: http://stackoverflow.com/questions/13726584/uploading-xlsx-or-docx-to-sharepoint-2007-from-asp-net-app-causing-file-c
