### PR TITLE
fix(python_django_s3): Call is_valid_policy where appropriate

### DIFF
--- a/python_django/s3/views.py
+++ b/python_django/s3/views.py
@@ -59,6 +59,8 @@ def handle_POST(request):
             # and NOT a policy document
             response_data = sign_headers(headers)
         else:
+            if not is_valid_policy(request_payload):
+                return make_response(400, {'invalid': True})
             response_data = sign_policy_document(request_payload)
         response_payload = json.dumps(response_data)
         return make_response(200, response_payload)


### PR DESCRIPTION
Note: This code returns a 400 error in case of failure, which is more appropriate than 500 to indicate that something is wrong with the request.
