### PR TITLE
Added isset() and empty() validation to two vars

### DIFF
--- a/php/s3/s3demo-cors.php
+++ b/php/s3/s3demo-cors.php
@@ -91,7 +91,7 @@ function getRequestMethod() {
     	parse_str($HTTP_RAW_POST_DATA, $_POST);
     }
 
-    if ($_POST['_method'] != null) {
+    if (isset($_POST['_method']) {
         return $_POST['_method'];
     }
 
@@ -135,9 +135,8 @@ function signRequest() {
     $contentAsObject = json_decode($responseBody, true);
     $jsonContent = json_encode($contentAsObject);
 
-    $headersStr = $contentAsObject["headers"];
-    if ($headersStr) {
-        signRestRequest($headersStr);
+    if (!empty($contentAsObject["headers"])) {
+        signRestRequest($contentAsObject["headers"]);
     }
     else {
         signPolicy($jsonContent);


### PR DESCRIPTION
Adding debugging code to the top of the server code:

   error_reporting(E_ALL);
   ini_set('display_errors', TRUE);

Brought out warnings that variables that were not being set before use.  Caused the upload to fail because unexpected error descriptions were being dumped into the response. Used isset / empty logic to check those variables before use.

Also probably needs to be changed on any other server examples that use the same logic.
