### PR TITLE
Make uploadName consistent regardless of chunking

### DIFF
--- a/php/traditional/handler.php
+++ b/php/traditional/handler.php
@@ -131,7 +131,7 @@ class UploadHandler {
 
                 $target = join(DIRECTORY_SEPARATOR, array($uploadDirectory, $uuid, $name));
                 //$target = $this->getUniqueTargetPath($uploadDirectory, $name);
-                $this->uploadName = $uuid.DIRECTORY_SEPARATOR.$name;
+                $this->uploadName = $name;
 
                 if (!file_exists($target)){
                     mkdir(dirname($target));


### PR DESCRIPTION
Currently if a file is not chunked, the `uploadName` is set to only the filename. If it is chunked, it is set to `uuid/filename`. This fix makes both cases use just the filename.
