### PR TITLE
PHP - Recursive removing of directories doesn't work (as intended) and might delete wrong files/directories

### DIFF
--- a/php/traditional/handler.php
+++ b/php/traditional/handler.php
@@ -288,10 +288,12 @@ class UploadHandler {
             if ($item == "." || $item == "..")
                 continue;
 
-            if (is_dir($item)){
-                $this->removeDir($item);
+            $path = join(DIRECTORY_SEPARATOR, array($dir, $item));
+            
+            if (is_dir($path)){
+                $this->removeDir($path);
             } else {
-                unlink(join(DIRECTORY_SEPARATOR, array($dir, $item)));
+                unlink($path);
             }
 
         }


### PR DESCRIPTION
Recursive removing of files and directories did not work as intended (and might have deleted wrong files (!))

The recursive removing of directories and files did not use the parent-directory of previous recusion-calls.
e.g. The recursion started at the "./foo"-directory and tried to delete "bar" - "bar" is an directory, so it has to recure. The recursion is called with "bar" only, so it would try to delete "./bar" instead of "./foo/bar". If "./bar" existed, it would delete the files in it. (!)
