### PR TITLE
for PHP 5.3 compatibility

### DIFF
--- a/php/traditional/handler.php
+++ b/php/traditional/handler.php
@@ -201,7 +201,7 @@ class UploadHandler {
         }
 
         $targetFolder = $uploadDirectory;
-        $url = parse_url($_SERVER['REQUEST_URI'])['path'];
+        $url = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
         $tokens = explode('/', $url);
         $uuid = $tokens[sizeof($tokens)-1];
 


### PR DESCRIPTION
the syntax `parse_url(...)['path']` works only in PHP 5.4+
see [example 7 of this page](http://php.net/manual/en/language.types.array.php#example-102).