### PR TITLE
check for null queryString in handleSignatureRequest()

### DIFF
--- a/java/s3/S3Uploads.java
+++ b/java/s3/S3Uploads.java
@@ -93,7 +93,7 @@ public class S3Uploads extends HttpServlet
         JsonElement contentJson = jsonParser.parse(req.getReader());
         JsonObject jsonObject = contentJson.getAsJsonObject();
 
-        if (req.getQueryString().contains("v4=true")) {
+        if (req.getQueryString() != null && req.getQueryString().contains("v4=true")) {
             handleV4SignatureRequest(jsonObject, contentJson, req, resp);
         }
         else {


### PR DESCRIPTION
check for null queryString in handleSignatureRequest() before performing contains() check. In Tomcat 8, this value is null when the query string is empty (Ah Java how you love the NPE's...)