### PR TITLE
Make sure hmac isn't given a unicode string

### DIFF
--- a/python/flask-fine-uploader-s3/app.py
+++ b/python/flask-fine-uploader-s3/app.py
@@ -38,6 +38,7 @@ def sign_policy(policy):
 
 def sign_headers(headers):
     """ Sign and return the headers for a chunked upload. """
+    headers = bytearray(headers, 'utf-8')  # hmac doesn't want unicode
     return {
         'signature': base64.b64encode(hmac.new(
             app.config.get('AWS_CLIENT_SECRET_KEY'), headers, hashlib.sha1).


### PR DESCRIPTION
So I ran into a problem with this today where the headers were unicode which isn't supported for python2 hmac.  Converting to a bytearray seems like a reasonable guard against this and might help others.